### PR TITLE
Fixed --quiet arg of utils/partition_citygs.py. Now it does something

### DIFF
--- a/internal/utils/citygs_partitioning_utils.py
+++ b/internal/utils/citygs_partitioning_utils.py
@@ -289,15 +289,16 @@ class CityGSPartitionableScene(PartitionableScene):
         func(ax, *args, **kwargs)
         plt.show(fig)
 
-    def save_plot(self, func: Callable, path: str, notebook=True, *args, **kwargs):
+    def save_plot(self, func: Callable, path: str, notebook=True, show=True, *args, **kwargs):
         plt.close()
         fig, ax = plt.subplots()
         func(ax, *args, **kwargs)
         plt.savefig(path, dpi=600)
-        if notebook:
-            plt.show(fig)
-        else:
-            plt.show()
+        if show:
+            if notebook:
+                plt.show(fig)
+            else:
+                plt.show()
 
 
 class CityGSPartitioning(Partitioning):

--- a/utils/partition_citygs.py
+++ b/utils/partition_citygs.py
@@ -127,7 +127,7 @@ if __name__ == "__main__":
         }
     )
 
-    scene.save_plot(scene.plot_partitions, os.path.join(output_path, "partitions.png"), notebook=False)
+    scene.save_plot(scene.plot_partitions, os.path.join(output_path, "partitions.png"), notebook=False, show=not args.quite)
 
     is_images_assigned_to_partitions = torch.logical_or(scene.is_camera_in_partition, scene.is_partitions_visible_to_cameras)
     print(f"Overall images assigned to partitions: {is_images_assigned_to_partitions.sum(-1)}")
@@ -176,6 +176,7 @@ if __name__ == "__main__":
             scene.plot_partition_assigned_cameras,
             os.path.join(output_path, "{}.png".format(scene.partition_coordinates.get_str_id(partition_idx))),
             False,
+            not args.quite,
             partition_idx,
             reoriented_point_cloud_xyz,
             point_rgbs,


### PR DESCRIPTION
Now, when you pass `--quiet` arg into the `utils/partition_citygs.py`, it prevents showing partition previews when its done, so you don't have to close those windows manually anymore. Useful to run automated command chains (via .sh and .bat files) without stopping the whole pipeline in order for user to check it out
Let me know if `--quiet` used for something else